### PR TITLE
Add SANs to certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # terraform-aws-acm-request-certificate [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-acm-request-certificate.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-acm-request-certificate)
 
-Terraform module to request an ACM certificate for a domain name and create a CNAME record in the DNZ zone to complete certificate validation 
+Terraform module to request an ACM certificate for a domain name and all its subdomains, and add CNAME records to the DNZ zone to complete certificate validation 
 
 
 ## Usage
+
+This example will request an SSL certificate for `example.com` and all its subdomains `*.example.com` (Subject Alternative Names)
 
 ```hcl
 module "acm_request_certificate" {
@@ -28,11 +30,11 @@ module "acm_request_certificate" {
 
 ## Outputs
 
-| Name                         | Description                                                                    |
-|:-----------------------------|:-------------------------------------------------------------------------------|
-| `id`                         | The ARN of the certificate                                                     |
-| `arn`                        | The ARN of the certificate                                                     |
-| `domain_validation_options`  | CNAME record that is added to the DNS zone to complete certificate validation  |
+| Name                         | Description                                                                      |
+|:-----------------------------|:---------------------------------------------------------------------------------|
+| `id`                         | The ARN of the certificate                                                       |
+| `arn`                        | The ARN of the certificate                                                       |
+| `domain_validation_options`  | CNAME records that are added to the DNS zone to complete certificate validation  |
 
 
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ module "acm_request_certificate" {
   domain_name                      = "example.com"
   proces_domain_validation_options = "true"
   ttl                              = "300"
-  subject_alternative_names        = "*.example.com"
+  subject_alternative_names        = ["*.example.com"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # terraform-aws-acm-request-certificate [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-acm-request-certificate.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-acm-request-certificate)
 
-Terraform module to request an ACM certificate for a domain name and all its subdomains, and add CNAME records to the DNZ zone to complete certificate validation 
+Terraform module to request an ACM certificate for a domain and add a CNAME record to the DNZ zone to complete certificate validation 
 
 
 ## Usage
 
-This example will request an SSL certificate for `example.com` and all its subdomains `*.example.com` (Subject Alternative Names)
+This example will request an SSL certificate for `example.com` domain
 
 ```hcl
 module "acm_request_certificate" {
@@ -13,6 +13,18 @@ module "acm_request_certificate" {
   domain_name                      = "example.com"
   proces_domain_validation_options = "true"
   ttl                              = "300"
+}
+```
+
+This example will request an SSL certificate for `example.com` domain and all its subdomains `*.example.com`
+
+```hcl
+module "acm_request_certificate" {
+  source                           = "git::https://github.com/cloudposse/terraform-aws-acm-request-certificate.git?ref=master"
+  domain_name                      = "example.com"
+  proces_domain_validation_options = "true"
+  ttl                              = "300"
+  subject_alternative_names        = "*.example.com"
 }
 ```
 
@@ -26,6 +38,7 @@ module "acm_request_certificate" {
 | `proces_domain_validation_options`  | `true`       | Flag to enable/disable processing of the record to add to the DNS zone to complete certificate validation   | No       |
 | `ttl`                               | `300`        | The TTL of the record to add to the DNS zone to complete certificate validation    | No       |
 | `tags`                              | `{}`         | Additional tags  (_e.g._ `map("BusinessUnit","XYZ")`                               | No       |
+| `subject_alternative_names`         | `[]`         | A list of domains that should be SANs in the issued certificate                    | No       |
 
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "aws_acm_certificate" "default" {
   domain_name               = "${var.domain_name}"
   validation_method         = "${var.validation_method}"
-  subject_alternative_names = ["*.${var.domain_name}"]
+  subject_alternative_names = ["${var.subject_alternative_names}"]
   tags                      = "${var.tags}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,8 @@
 resource "aws_acm_certificate" "default" {
-  domain_name       = "${var.domain_name}"
-  validation_method = "${var.validation_method}"
-  tags              = "${var.tags}"
+  domain_name               = "${var.domain_name}"
+  validation_method         = "${var.validation_method}"
+  subject_alternative_names = ["*.${var.domain_name}"]
+  tags                      = "${var.tags}"
 }
 
 data "aws_route53_zone" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,3 +26,9 @@ variable "tags" {
   default     = {}
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }
+
+variable "subject_alternative_names" {
+  type        = "list"
+  default     = []
+  description = "A list of domains that should be SANs in the issued certificate"
+}


### PR DESCRIPTION
## what
* Add `subject_alternative_names`

## why
* To request a certificate for the domain and SANs
