### PR TITLE
Add output to allow dependencies to run when cert is ready

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,8 @@ output "domain_validation_options" {
   value       = aws_acm_certificate.default.*.domain_validation_options
   description = "CNAME records that are added to the DNS zone to complete certificate validation"
 }
+
+output "validation_id" {
+  value       = join("", aws_acm_certificate_validation.default.*.id)
+  description = "The ID of the certificate validation"
+}


### PR DESCRIPTION
## what
* Resources/modules that depend on an ACM certificate to be created *and* validated need something to indicate that the cert is ready before they begin their work.
* An example is that one can set a tag of `CertDate = module.acm.validation_id` on the depending resource.

## why
* Dependency order is not maintained as (for example) Beanstalk will begin its reconfiguration of a ELB listener once the `aws_acm_certificate` resource is completed.  But this does not mean that the certificate have been *validated* by ACM and is ready for use.  We need something to show Beanstalk that the certificate is ready for use (ie validated).
* Presenting output from `aws_acm_certificate_validation` should solve this dependency problem.

## references
* [`aws_acm_certificate_validation` Attributes Reference](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation#attributes-reference)
