### PR TITLE
Add zone id

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Available targets:
 | <a name="input_ttl"></a> [ttl](#input\_ttl) | The TTL of the record to add to the DNS zone to complete certificate validation | `string` | `"300"` | no |
 | <a name="input_validation_method"></a> [validation\_method](#input\_validation\_method) | Method to use for validation, DNS or EMAIL | `string` | `"DNS"` | no |
 | <a name="input_wait_for_certificate_issued"></a> [wait\_for\_certificate\_issued](#input\_wait\_for\_certificate\_issued) | Whether to wait for the certificate to be issued by ACM (the certificate status changed from `Pending Validation` to `Issued`) | `bool` | `false` | no |
+| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | The zone id of the Route53 Hosted Zone which can be used instead of `var.zone_name`. | `string` | `null` | no |
 | <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | The name of the desired Route53 Hosted Zone | `string` | `""` | no |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -53,6 +53,7 @@
 | <a name="input_ttl"></a> [ttl](#input\_ttl) | The TTL of the record to add to the DNS zone to complete certificate validation | `string` | `"300"` | no |
 | <a name="input_validation_method"></a> [validation\_method](#input\_validation\_method) | Method to use for validation, DNS or EMAIL | `string` | `"DNS"` | no |
 | <a name="input_wait_for_certificate_issued"></a> [wait\_for\_certificate\_issued](#input\_wait\_for\_certificate\_issued) | Whether to wait for the certificate to be issued by ACM (the certificate status changed from `Pending Validation` to `Issued`) | `bool` | `false` | no |
+| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | The zone id of the Route53 Hosted Zone which can be used instead of `var.zone_name`. | `string` | `null` | no |
 | <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | The name of the desired Route53 Hosted Zone | `string` | `""` | no |
 
 ## Outputs

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,6 +13,7 @@ module "zone" {
 
 module "acm_request_certificate" {
   source                            = "../../"
+  domain_name                       = module.zone.zone_name
   zone_id                           = module.zone.zone_id
   validation_method                 = var.validation_method
   ttl                               = var.ttl

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,7 +13,7 @@ module "zone" {
 
 module "acm_request_certificate" {
   source                            = "../../"
-  domain_name                       = module.zone.zone_name
+  zone_id                           = module.zone.zone_id
   validation_method                 = var.validation_method
   ttl                               = var.ttl
   subject_alternative_names         = ["*.${module.zone.zone_name}"]

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,8 @@ locals {
 
 data "aws_route53_zone" "default" {
   count        = local.process_domain_validation_options ? 1 : 0
-  name         = local.zone_name
+  zone_id      = var.zone_id
+  name         = try(length(var.zone_id), 0) == 0 ? local.zone_name : null
   private_zone = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "zone_name" {
 variable "zone_id" {
   type        = string
   default     = null
-  description = "The zone id of the Route53 Hosted Zone which can be used instead of `var.zone_name`.
+  description = "The zone id of the Route53 Hosted Zone which can be used instead of `var.zone_name`."
 }
 
 variable "certificate_transparency_logging_preference" {

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "zone_name" {
   description = "The name of the desired Route53 Hosted Zone"
 }
 
+variable "zone_id" {
+  type        = string
+  default     = null
+  description = "The zone id of the Route53 Hosted Zone which can be used instead of `var.zone_name`.
+}
+
 variable "certificate_transparency_logging_preference" {
   type        = bool
   default     = true


### PR DESCRIPTION
## what
* Add zone_id

## why
* Create an implicit link between zone creation and acm creation
* This gives the consumer the option to use domain name, zone name, or zone id to use the data source to retrieve the existing hosted zone

## references
* Closes https://github.com/cloudposse/terraform-aws-acm-request-certificate/issues/24
* Previous PR https://github.com/cloudposse/terraform-aws-acm-request-certificate/pull/45
    * Did not see this PR unfortunately. It does not update the failing test so if this gets merged, I'll close the other PR.