### PR TITLE
Private CA: Skip validation method, correct data source input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
   process_domain_validation_options = local.enabled && var.process_domain_validation_options && var.validation_method == "DNS"
   domain_validation_options_set     = local.process_domain_validation_options ? aws_acm_certificate.default.0.domain_validation_options : toset([])
   public_enabled                    = var.certificate_authority_arn == null
-  private_enabled                   = !local.public_enabled
+  private_enabled                   = ! local.public_enabled
 }
 
 resource "aws_acm_certificate" "default" {


### PR DESCRIPTION
## what
* Skip validation method, correct data source input

## why
* Validation method is only applicable for public hosted zone acm certs
* Use correct private_zone input for route53 zone data source

## references
* N/A
