### PR TITLE
adding validation certificate_arn output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -24,7 +24,3 @@ output "validation_arn" {
   description = "The ARN of the certificate validation"
 }
 
-output "validation_status" {
-  value       = join("", aws_acm_certificate.default.*.status)
-  description = "The STATUS of the certificate"
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,9 @@ output "validation_id" {
   value       = join("", aws_acm_certificate_validation.default.*.id)
   description = "The ID of the certificate validation"
 }
+
+
+output "validation_status" {
+  value       = join("", aws_acm_certificate.default.*.status)
+  description = "The STATUS of the certificate"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,11 @@ output "validation_id" {
 }
 
 
+output "validation_arn" {
+  value       = join("", aws_acm_certificate_validation.default.*.certificate_arn)
+  description = "The ARN of the certificate validation"
+}
+
 output "validation_status" {
   value       = join("", aws_acm_certificate.default.*.status)
   description = "The STATUS of the certificate"

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,7 +18,6 @@ output "validation_id" {
   description = "The ID of the certificate validation"
 }
 
-
 output "validation_arn" {
   value       = join("", aws_acm_certificate_validation.default.*.certificate_arn)
   description = "The ARN of the certificate validation"

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "domain_name" {
   description = "A domain name for which the certificate should be issued"
 
   validation {
-    condition     = ! can(regex("[A-Z]", var.domain_name))
+    condition     = !can(regex("[A-Z]", var.domain_name))
     error_message = "Domain name must be lower-case."
   }
 }


### PR DESCRIPTION
## what
* added acm_certificate_validation.certification_arn output

## why
* to avoid alb module can't create listener because of not validated cert
* use this output as certification arn in alb module


## references
* [#58](https://github.com/cloudposse/terraform-aws-acm-request-certificate/issues/58)
* closes #58 

