### PR TITLE
fix spilt of root domain

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ locals {
   )
   domain_to_zone = {
     for domain in local.all_domains :
-    domain => join(".", slice(split(".", domain), 1, length(split(".", domain))))
+    domain => length(split(".", domain)) > 2 ? join(".", slice(split(".", domain), 1, length(split(".", domain)))) : domain
   }
   unique_zones = distinct(values(local.domain_to_zone))
 }


### PR DESCRIPTION
## what
This fixes what was mentioned in - https://github.com/cloudposse/terraform-aws-acm-request-certificate/pull/66

## why
Adding a simple length check to where domains get update in an array fixes the mentioned issue.
```
  Error: no matching Route53Zone found
  
    with module.acm_request_certificate.data.aws_route53_zone.default["io"],
    on .terraform/modules/acm_request_certificate/main.tf line 38, in data "aws_route53_zone" "default":
    38: data "aws_route53_zone" "default" {
```

## references
* https://github.com/cloudposse/terraform-aws-acm-request-certificate/pull/66
