### PR TITLE
chore: Add certificate export option

### DIFF
--- a/examples/complete/fixtures.us-west-1.tfvars
+++ b/examples/complete/fixtures.us-west-1.tfvars
@@ -6,7 +6,7 @@ stage = "test"
 
 name = "test-zone-2"
 
-parent_zone_name = "testing.cloudposse.co"
+parent_zone_name = "modules.cptest.test-automation.app"
 
 validation_method = "DNS"
 

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,25 +1,25 @@
 output "parent_zone_id" {
-  value = module.zone.parent_zone_id
+  value       = module.zone.parent_zone_id
   description = "The zone id of the parent Route53 Hosted Zone"
 }
 
 output "parent_zone_name" {
-  value = module.zone.parent_zone_name
+  value       = module.zone.parent_zone_name
   description = "The name of the parent Route53 Hosted Zone"
 }
 
 output "zone_id" {
-  value = module.zone.zone_id
+  value       = module.zone.zone_id
   description = "The zone id of the Route53 Hosted Zone"
 }
 
 output "zone_name" {
-  value = module.zone.zone_name
+  value       = module.zone.zone_name
   description = "The name of the desired Route53 Hosted Zone"
 }
 
 output "zone_fqdn" {
-  value = module.zone.fqdn
+  value       = module.zone.fqdn
   description = "The FQDN of the desired Route53 Hosted Zone"
 }
 

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,21 +1,26 @@
 output "parent_zone_id" {
   value = module.zone.parent_zone_id
+  description = "The zone id of the parent Route53 Hosted Zone"
 }
 
 output "parent_zone_name" {
   value = module.zone.parent_zone_name
+  description = "The name of the parent Route53 Hosted Zone"
 }
 
 output "zone_id" {
   value = module.zone.zone_id
+  description = "The zone id of the Route53 Hosted Zone"
 }
 
 output "zone_name" {
   value = module.zone.zone_name
+  description = "The name of the desired Route53 Hosted Zone"
 }
 
 output "zone_fqdn" {
   value = module.zone.fqdn
+  description = "The FQDN of the desired Route53 Hosted Zone"
 }
 
 output "certificate_id" {

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ resource "aws_acm_certificate" "default" {
 
   options {
     certificate_transparency_logging_preference = var.certificate_transparency_logging_preference ? "ENABLED" : "DISABLED"
+    export = var.certificate_export ? "ENABLED" : "DISABLED"
   }
 
   tags = module.this.tags

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "aws_acm_certificate" "default" {
 
   options {
     certificate_transparency_logging_preference = var.certificate_transparency_logging_preference ? "ENABLED" : "DISABLED"
-    export = var.certificate_export ? "ENABLED" : "DISABLED"
+    export                                      = var.certificate_export ? "ENABLED" : "DISABLED"
   }
 
   tags = module.this.tags

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -64,7 +64,7 @@ func TestExamplesComplete(t *testing.T) {
 	certificateArn := terraform.Output(t, terraformOptions, "certificate_arn")
 
 	// Verify we're getting back the outputs we expect
-	assert.Contains(t, certificateArn, "arn:aws:acm:us-west-1:126450723953:certificate/")
+	assert.Contains(t, certificateArn, "arn:aws:acm:us-west-1:799847381734:certificate/")
 }
 
 func TestExamplesCompleteDisabled(t *testing.T) {

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -56,7 +56,7 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	zoneName := terraform.Output(t, terraformOptions, "zone_name")
 
-	expectedZoneName := "test-zone-2.testing.cloudposse.co"
+	expectedZoneName := "test-zone-2.modules.cptest.test-automation.app"
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, expectedZoneName, zoneName)
 

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,12 @@ variable "zone_id" {
   description = "The zone id of the Route53 Hosted Zone which can be used instead of `var.zone_name`."
 }
 
+variable "certificate_export" {
+  type        = bool
+  default     = false
+  description = "Specifies whether the certificate can be exported"
+}
+
 variable "certificate_transparency_logging_preference" {
   type        = bool
   default     = true

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.40"
+      version = ">= 6.4.0"
     }
   }
 }


### PR DESCRIPTION
## what

- Add `var.certificate_export`

## why

- Add ability to export the requested certificate

## references

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#export-1
- https://aws.amazon.com/blogs/aws/aws-certificate-manager-introduces-exportable-public-ssl-tls-certificates-to-use-anywhere/